### PR TITLE
Endre location header på 401

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,19 @@ Håndterer OIDC-innlogging, samt veksling til korrekt `on_behalf_of`- access tok
 
 Når det kreves en ny innlogging fra brukeren vil proxyen gi en 401 error med `Location` header satt til hvor brukeren må redirectes for å gjøre innloggingen. Dette for at applikasjonen skal få mulighet til å lagre unna eventuell state før man redirecter til login.
 
+## GCP
+
+### Opprette kubernetes secret
+```
+kubectl create secret generic <min-secret> -n <mitt-team> from-literal=SESSION_ID_COOKIE_SIGN_SECRET=<min-sign-secret> --from-literal= SESSION_ID_COOKIE_VERIFY_SECRET=<min-verify-secret>
+```
+
+### Bruke secret i naiserator 
+```
+  envFrom:
+    - secret: <min-secret>
+```
+
 ## End points
 
 ### GET /login?redirect_uri=

--- a/src/server/utils/proxy.js
+++ b/src/server/utils/proxy.js
@@ -1,4 +1,4 @@
-import { getTokenOnBehalfOf, isAuthenticated, prepareAndGetAuthorizationUrl } from './auth';
+import { getTokenOnBehalfOf, isAuthenticated } from './auth';
 import config from './config';
 import logger from './log';
 import url from 'url';
@@ -12,8 +12,7 @@ export const getProxyOptions = (api, authClient) => ({
         logger.info(`Authenticated = ${authenticated}`);
         if (!authenticated) {
             const redirectUri = getRedirectUriFromHeader({ request });
-            const authorizationUrl = prepareAndGetAuthorizationUrl({ request, authClient, redirectUri });
-            response.header('Location', authorizationUrl);
+            response.header('Location', `${config.oidcAuthProxyBaseUrl}/login?redirect_uri=${redirectUri}`);
             response.sendStatus(401);
         }
         return authenticated;

--- a/startup-utils/start-for-local-dev.sh
+++ b/startup-utils/start-for-local-dev.sh
@@ -5,4 +5,4 @@ bash ./create-env-file.sh ../.env localhost
 docker-compose down
 docker-compose pull -q
 
-docker-compose up -d azure-mock
+docker-compose up -d azure-mock redis


### PR DESCRIPTION
Eneste stedet som nå kommer til å bruke 'prepareAndGetAuthorizationUrl' etter dette er  /login

Endrer at Location header som sendes med når man ikke er logget inn peker på /login på proxyen istedenfor å generere en URL til Azure. Blir istedenfor redirectet fra /login til Azure slik at vi kun har ett sted som kaller 'prepareAndGetAuthorizationUrl' som i sin tur håndterer state & nonce.