### PR TITLE
Det er mulig å registrere idporten-clienter via NAIS-platformen.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,8 +8,9 @@ COPY --from=navikt-common /dumb-init /dumb-init
 
 COPY docker/start-node-server.sh /run-script.sh
 COPY docker/import-azure-credentials.sh /init-scripts/20-import-azure-credentials.sh
+COPY docker/import-idporten-credentials.sh /init-scripts/21-import-idporten-credentials.sh
 
-RUN chmod +x /entrypoint.sh /run-script.sh /init-scripts/20-import-azure-credentials.sh
+RUN chmod +x /entrypoint.sh /run-script.sh /init-scripts/20-import-azure-credentials.sh /init-scripts/21-import-idporten-credentials.sh
 RUN apk add jq
 
 COPY dist ./dist

--- a/docker/import-idporten-credentials.sh
+++ b/docker/import-idporten-credentials.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env sh
+
+echo "Importing Idporten credentials"
+
+if test -d /var/run/secrets/nais.io/idporten;
+then
+    FILE_NAME=/var/run/secrets/nais.io/idporten/IDPORTEN_CLIENT_JWK
+    VALUE=$(cat $FILE_NAME | jq '.keys[0]')
+
+    export CLIENT_ID=$IDPORTEN_CLIENT_ID
+    export DISCOVERY_URL=$IDPORTEN_WELL_KNOWN_URL
+    export JWK=$VALUE
+fi


### PR DESCRIPTION
Når dette gjøres får containeren automatisk satt miljøvariabler og filer:
https://doc.nais.io/security/auth/idporten/#runtime-variables-credentials

Denne PRen legger til et import-idporten-credentials skript, som fungerer på samme måte som det eksisterende import-azure-credentials.sh.
Den sjekker om idporten registreringen er tatt i bruk. Dersom den er tatt i bruk så mapper den om navnet på en del env-variabler og JWK filen.