### PR TITLE
Fjerne `keys` fra `JWK`-import for `idporten`

### DIFF
--- a/docker/import-idporten-credentials.sh
+++ b/docker/import-idporten-credentials.sh
@@ -5,7 +5,7 @@ echo "Importing Idporten credentials"
 if test -d /var/run/secrets/nais.io/idporten;
 then
     FILE_NAME=/var/run/secrets/nais.io/idporten/IDPORTEN_CLIENT_JWK
-    VALUE=$(cat $FILE_NAME | jq '.keys[0]')
+    VALUE=$(cat $FILE_NAME)
 
     export CLIENT_ID=$IDPORTEN_CLIENT_ID
     export DISCOVERY_URL=$IDPORTEN_WELL_KNOWN_URL


### PR DESCRIPTION
Fjerner utenhenting av `keys` fra idporten importen av JWK. 
Formatet på JWK-filen for idporten og azure er litt forskjellig. Azure har wrappet sertifikatet inni "keys". Slik er det ikke for idporten. 

JWK-filen for azure ser slik ut: 
```
{
  "keys": [
    {
        "use": "sig",
        "kty": "RSA",
        "kid": "jXDxKRE6a4jogcc4HgkDq3uVgQ0",
        ....
    }
  ]
}
```
https://doc.nais.io/security/auth/azure-ad/#runtime-variables-credentials 

Mens for idporten ser den slik ut: 
```
{
  "use": "sig",
  "kty": "RSA",
  "kid": "jXDxKRE6a4jogcc4HgkDq3uVgQ0",
   ....
}
```
https://doc.nais.io/security/auth/idporten/#runtime-variables-credentials