### PR TITLE
Fikse dobbel json-parsing av ADDITIONAL_AUTHORIZATION_PARAMETERS 

### DIFF
--- a/src/server/utils/authUtil.test.js
+++ b/src/server/utils/authUtil.test.js
@@ -1,6 +1,4 @@
-import {convertJsonToAuthorizationParameters} from "./authUtils";
-
-const {getAuthorizationParameters} = require("./authUtils");
+import {getAuthorizationParameters} from "./authUtils";
 
 describe("getAuthorizationParameters", () => {
     const originalScope = "original scopes"
@@ -9,10 +7,10 @@ describe("getAuthorizationParameters", () => {
     const originalState = "state1234"
 
     it("should append new parameters", () => {
-        const additionalParameters = {
-            resource: "nav.no",
-            additionalPropertyThatDontExist: "tull001"
-        }
+        const additionalParameters = JSON.parse(`{
+            "resource": "nav.no",
+            "additionalPropertyThatDontExist": "tull001"
+        }`)
 
         const allParameters = getAuthorizationParameters(additionalParameters, originalScope, originalRedirectUri, originalNonce, originalState);
 
@@ -20,17 +18,23 @@ describe("getAuthorizationParameters", () => {
         expect(allParameters.additionalPropertyThatDontExist).toBe("tull001"); // Possible since AuthorizationParameters accepts other properties: [key: string]: unknown;
     });
 
-    it("should contain original parameters", () => {
-        const additionalParameters = {}
+    it("should contain original parameters when additionalParameters is undefined", () => {
+        const additionalParameters = undefined
 
         const allParameters = getAuthorizationParameters(additionalParameters, originalScope, originalRedirectUri, originalNonce, originalState);
 
         expect(allParameters.response_mode).toBe("form_post");
         expect(allParameters.response_type).toBe("code");
+        expect(allParameters.scope).toBe(originalScope);
+        expect(allParameters.redirect_uri).toBe(originalRedirectUri);
+        expect(allParameters.state).toBe(originalState);
+        expect(allParameters.nonce).toBe(originalNonce);
     });
 
-    it("should handle undefined", () => {
-        const allParameters = getAuthorizationParameters(undefined, originalScope, originalRedirectUri, originalNonce, originalState);
+    it("should contain original parameters when additionalParameters is empty", () => {
+        const additionalParameters = JSON.parse(`{}`)
+
+        const allParameters = getAuthorizationParameters(additionalParameters, originalScope, originalRedirectUri, originalNonce, originalState);
 
         expect(allParameters.response_mode).toBe("form_post");
         expect(allParameters.response_type).toBe("code");
@@ -41,14 +45,14 @@ describe("getAuthorizationParameters", () => {
     });
 
     it("should not override existing properties", () => {
-        const additionalParameters = {
-            response_mode: 'new responseMode',
-            response_type: 'new responseType',
-            scope: 'new scopes',
-            redirect_uri: "new redirectUri",
-            nonce: "new nonce",
-            state: "new state",
-        }
+        const additionalParameters = JSON.parse(`{
+            "response_mode": "new responseMode",
+            "response_type": "new responseType",
+            "scope": "new scopes",
+            "redirect_uri": "new redirectUri",
+            "nonce": "new nonce",
+            "state": "new state"
+        }`)
 
         const allParameters = getAuthorizationParameters(additionalParameters, originalScope, originalRedirectUri, originalNonce, originalState);
 
@@ -58,24 +62,5 @@ describe("getAuthorizationParameters", () => {
         expect(allParameters.redirect_uri).toBe(originalRedirectUri);
         expect(allParameters.state).toBe(originalState);
         expect(allParameters.nonce).toBe(originalNonce);
-    });
-});
-
-describe("convertJsonToAuthorizationParameters", () => {
-    it("should convert json to AuthorizationParameter with resource", () => {
-        const json = `
-        {
-            "resource": "nav.no"
-        }`
-
-        let authorizationParameters = convertJsonToAuthorizationParameters(json);
-
-        expect(authorizationParameters.resource).toBe("nav.no");
-    });
-
-    it("should convert undefined", () => {
-        let authorizationParameters = convertJsonToAuthorizationParameters(undefined);
-
-        expect(authorizationParameters.resource).toBe(undefined);
     });
 });

--- a/src/server/utils/authUtils.js
+++ b/src/server/utils/authUtils.js
@@ -11,9 +11,3 @@ export const getAuthorizationParameters = (additionalAuthorizationParameters, sc
     // If additionalParameters should override originalParameters then this should be reordered: {...originalAuthorizationParameters, ...config.additionalAuthorizationParameters};
     return {...additionalAuthorizationParameters, ...originalAuthorizationParameters};
 };
-
-export const convertJsonToAuthorizationParameters = additionalAuthorizationParametersJson => {
-    if (!additionalAuthorizationParametersJson) return {}
-
-    return JSON.parse(additionalAuthorizationParametersJson);
-};

--- a/src/server/utils/config.js
+++ b/src/server/utils/config.js
@@ -1,5 +1,4 @@
 import logger from './log';
-import {convertJsonToAuthorizationParameters} from "./authUtils";
 
 const environmentVariable = ({ name, secret = false, required = true }) => {
     if (!process.env[name] && required) {
@@ -18,7 +17,7 @@ const environmentVariableAsJson = ({ name, secret = false, required = true }) =>
 
     let env = environmentVariable({ name, secret, required });
     if (!env && !required) {
-        logger.info(`Valgfri environment variable '${name}'.`);
+        logger.info(`Valgfri environment variable '${name}' er ikke satt.`);
         return undefined
     }
     try {
@@ -67,14 +66,12 @@ const getProxyConfig = () => {
 };
 
 const getAdditionalAuthorizationParameters = () => {
-    let additionalAuthorizationParametersJson = environmentVariableAsJson(
+    return environmentVariableAsJson(
         {
             name: 'ADDITIONAL_AUTHORIZATION_PARAMETERS',
             secret: false,
             required: false
         });
-
-    return convertJsonToAuthorizationParameters(additionalAuthorizationParametersJson)
 };
 
 const clientId = environmentVariable({ name: 'CLIENT_ID' });


### PR DESCRIPTION
Fjerne convertJsonToAuthorizationParameters() som kun gjorde en ny json-parse av et objekt som allerede var json-parset.
Dette førte til feilmeldingen `Unexpected token o in JSON at position 1`
Feilen påvirket kun apper som har ADDITIONAL_AUTHORIZATION_PARAMETERS satt. 

Endret også testene til å ta inn en string, parse til json og deretter sjekke verdiene. 

(convertJsonToAuthorizationParameters ble lagt til da jeg ønsket å parse json til AuthorizationParameters med typescript. Men jeg fant ut at det ikke ga så mye verdi) 

✅ Testet at resource nå er med i /authorize -kallet om ADDITIONAL_AUTHORIZATION_PARAMETERS  er satt 
![image](https://user-images.githubusercontent.com/4296877/119015097-e1d60800-b998-11eb-9c96-019b363bbfb3.png)
