### PR TITLE
Muliggjør token-exhange med en annen klient enn autentiserings-flyten

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,12 +222,15 @@ Følgende fremgangsmåte vil ikke fungere for Chrome, så bruk Firefox:
    sameSite = 'none';
    ```
    (Dette ligger inni !https if'en)
-   NB: Dette fungerer ikke i `Chrome`. Bruk `Firefox` isteden. 
+   NB: Dette fungerer ikke i `Chrome`. Bruk `Firefox` isteden.
+1. Pass på at frontenden din kjører på `localhost:3005` (eller endre på `APPLICATION_BASE_URL`)  
+   og går mot oidc-auth-proxy på `localhost:3000`.
 1. Kjør opp med docker-compose: 
    ```
    cd startup-utils/
    ./start-for-integration-tests.sh
    ```
+   Husk å bruke Firefox!
 
 # Henvendelser
 

--- a/README.md
+++ b/README.md
@@ -184,7 +184,7 @@ Følgende fremgangsmåte vil ikke fungere for Chrome, så bruk Firefox:
    * Variabler som starter på `<BACKEND...>` byttes ut avhengig av hvilke apper du kjører. 
    * Variabler som starter på `<test-app-...>` byttes ut med verdiene til **_TestKlientene_** 
      (se lenke i ingress, i dag ligger disse verdiene i vault). \
-     Merk `<test-app-1_AZURE_APP_JWKS>` skal være uten `keys[]`. 
+     Merk `<test-app-1_AZURE_APP_JWKS>` skal være uten wrapperen `keys[]`. 
    
    #### Idporten:
    ```

--- a/README.md
+++ b/README.md
@@ -177,12 +177,13 @@ Følgende fremgangsmåte vil ikke fungere for Chrome, så bruk Firefox:
    echo JWK='<test-app-1_AZURE_APP_JWKS>' >> $ENV_PATH
    echo DISCOVERY_URL="'<test-app-1_AZURE_APP_WELL_KNOWN_URL>'" >> $ENV_PATH
    echo LOGIN_SCOPES="'openid profile <test-app-1_AZURE_APP_CLIENT_ID>/.default'" >> $ENV_PATH
-   echo PROXY_CONFIG="'{\"apis\":[{\"path\":\"<BACKEND_PATH>\",\"url\":\"<BACKEND_URL>",\"scopes\":\"<test-app-2_AZURE_APP_CLIENT_ID>>/.default\"}]}'" >> $ENV_PATH
+   echo PROXY_CONFIG="'{\"apis\":[{\"path\":\"<BACKEND_PATH>\",\"url\":\"<BACKEND_URL>\",\"scopes\":\"<test-app-2_AZURE_APP_CLIENT_ID>/.default\"}]}'" >> $ENV_PATH
    echo OIDC_AUTH_PROXY_BASE_URL="'http://localhost:3000'" >> $ENV_PATH
    echo APPLICATION_BASE_URL="'http://localhost:3005'" >> $ENV_PATH
    ```
    * Variabler som starter på `<BACKEND...>` byttes ut avhengig av hvilke apper du kjører. 
-   * Variabler som starter på `<test-app-...>` byttes ut med verdiene til **_TestKlientene_** (se lenke i ingress). \
+   * Variabler som starter på `<test-app-...>` byttes ut med verdiene til **_TestKlientene_** 
+     (se lenke i ingress, i dag ligger disse verdiene i vault). \
      Merk `<test-app-1_AZURE_APP_JWKS>` skal være uten `keys[]`. 
    
    #### Idporten:
@@ -202,7 +203,8 @@ Følgende fremgangsmåte vil ikke fungere for Chrome, så bruk Firefox:
    echo OIDC_AUTH_PROXY_BASE_URL="'http://localhost:3000'" >> $ENV_PATH
    echo APPLICATION_BASE_URL="'http://localhost:3005'" >> $ENV_PATH
    ```
-   * Variabler som starter på `<IDPORTEN-...>` byttes ut med verdiene til _**TestKlienten**_ (se lenke i ingress). 
+   * Variabler som starter på `<IDPORTEN-...>` byttes ut med verdiene til _**TestKlienten**_ 
+     (se lenke i ingress, i dag ligger disse verdiene i vault). 
    * Variabler som starter på `<BACKEND...>` byttes ut avhengig av hvilke apper du kjører. 
    * Variabler som starter på `<din-...>` byttes ut med verdier til de kjørende poddene du har i miljø. \
      (Det finnes ingen testklient for TokenX)

--- a/README.md
+++ b/README.md
@@ -174,7 +174,7 @@ Følgende fremgangsmåte vil ikke fungere for Chrome, så bruk Firefox:
    #### AzureAd:
    ```
    echo CLIENT_ID='<test-app-1_AZURE_APP_CLIENT_ID>' >> $ENV_PATH
-   echo JWK='<test-app-1_AZURE_APP_JWKS>' >> $ENV_PATH
+   echo JWK='<test-app-1_AZURE_APP_JWK>' >> $ENV_PATH
    echo DISCOVERY_URL="'<test-app-1_AZURE_APP_WELL_KNOWN_URL>'" >> $ENV_PATH
    echo LOGIN_SCOPES="'openid profile <test-app-1_AZURE_APP_CLIENT_ID>/.default'" >> $ENV_PATH
    echo PROXY_CONFIG="'{\"apis\":[{\"path\":\"<BACKEND_PATH>\",\"url\":\"<BACKEND_URL>\",\"scopes\":\"<test-app-2_AZURE_APP_CLIENT_ID>/.default\"}]}'" >> $ENV_PATH
@@ -184,7 +184,7 @@ Følgende fremgangsmåte vil ikke fungere for Chrome, så bruk Firefox:
    * Variabler som starter på `<BACKEND...>` byttes ut avhengig av hvilke apper du kjører. 
    * Variabler som starter på `<test-app-...>` byttes ut med verdiene til **_TestKlientene_** 
      (se lenke i ingress, i dag ligger disse verdiene i vault). \
-     Merk `<test-app-1_AZURE_APP_JWKS>` skal være uten wrapperen `keys[]`. 
+     (Merk `<test-app-1_AZURE_APP_JWK>` skal være uten wrapperen `keys[]`.) 
    
    #### Idporten:
    ```

--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ npm run start-dev
 Om man ved åpning av `http://localhost:8101/login` havner på `http://localhost:8101/api/azure-mock/audience-check` med HTTP 200 response fungerer alt som det skal.
 
 ## Ved lokal kjøring mot Idporten eller AzureAd direkte: 
-Ved kjøring lokalt kan man bruke [disse TestKlientene](https://security.labs.nais.io/pages/utvikling/lokalt.html#testklienter). 
+Ved kjøring lokalt kan man bruke [disse **_TestKlientene_**](https://security.labs.nais.io/pages/utvikling/lokalt.html#testklienter). 
 De er registrert i AzureAd og Idporten med `http://localhost:3000/oauth2/callback` som tillat redirectUri. 
 Følgende fremgangsmåte vil ikke fungere for Chrome, så bruk Firefox:   
 1. Oppdater og legg til nødvendige miljøvariabler i `startup-utils/create-env-files.sh`
@@ -182,7 +182,7 @@ Følgende fremgangsmåte vil ikke fungere for Chrome, så bruk Firefox:
    echo APPLICATION_BASE_URL="'http://localhost:3005'" >> $ENV_PATH
    ```
    * Variabler som starter på `<BACKEND...>` byttes ut avhengig av hvilke apper du kjører. 
-   * Variabler som starter på `<test-app-...>` byttes ut med verdiene til TestKlientene. \
+   * Variabler som starter på `<test-app-...>` byttes ut med verdiene til **_TestKlientene_** (se lenke i ingress). \
      Merk `<test-app-1_AZURE_APP_JWKS>` skal være uten `keys[]`. 
    
    #### Idporten:
@@ -202,13 +202,13 @@ Følgende fremgangsmåte vil ikke fungere for Chrome, så bruk Firefox:
    echo OIDC_AUTH_PROXY_BASE_URL="'http://localhost:3000'" >> $ENV_PATH
    echo APPLICATION_BASE_URL="'http://localhost:3005'" >> $ENV_PATH
    ```
-   * Variabler som starter på `<IDPORTEN-...>` byttes ut med verdiene til TestKlienten. 
+   * Variabler som starter på `<IDPORTEN-...>` byttes ut med verdiene til _**TestKlienten**_ (se lenke i ingress). 
    * Variabler som starter på `<BACKEND...>` byttes ut avhengig av hvilke apper du kjører. 
    * Variabler som starter på `<din-...>` byttes ut med verdier til de kjørende poddene du har i miljø. \
      (Det finnes ingen testklient for TokenX)
    </details>
    <br>
-1. Rename alle forekomster av `/oidc/callback` til `/oauth2/callback`. Det er kun denne pathen som er registrert.
+1. Rename alle forekomster av `/oidc/callback` til `/oauth2/callback` i hele koden. Det er kun denne pathen som er registrert.
 1. Endre `services.oidc-auth-proxy.ports` i `startup-utils/docker-compose.yml` til: 
    ```
      - "3000:8101"
@@ -219,6 +219,7 @@ Følgende fremgangsmåte vil ikke fungere for Chrome, så bruk Firefox:
    secure = false;
    sameSite = 'none';
    ```
+   (Dette ligger inni !https if'en)
    NB: Dette fungerer ikke i `Chrome`. Bruk `Firefox` isteden. 
 1. Kjør opp med docker-compose: 
    ```

--- a/docker/import-idporten-credentials.sh
+++ b/docker/import-idporten-credentials.sh
@@ -11,3 +11,15 @@ then
     export DISCOVERY_URL=$IDPORTEN_WELL_KNOWN_URL
     export JWK=$VALUE
 fi
+
+echo "Importing TokenX credentials"
+
+if test -d /var/run/secrets/nais.io/jwker;
+then
+    FILE_NAME=/var/run/secrets/nais.io/jwker/TOKEN_X_PRIVATE_JWK
+    VALUE=$(cat $FILE_NAME)
+
+    export TOKEN_EXCHANGE_CLIENT_ID=$TOKEN_X_CLIENT_ID
+    export TOKEN_EXCHANGE_DISCOVERY_URL=$TOKEN_X_WELL_KNOWN_URL
+    export TOKEN_EXCHANGE_JWK=$VALUE
+fi

--- a/src/server/index.js
+++ b/src/server/index.js
@@ -15,7 +15,7 @@ import { loginRoutes } from './routes/login';
 import { logoutRoutes } from './routes/logout';
 import { meRoutes } from './routes/me';
 
-export default (authClient) => {
+export default (authClient, tokenExchangeClient) => {
     const server = express();
     const sessionStore = getSessionStore(session);
 
@@ -56,10 +56,10 @@ export default (authClient) => {
 
     server.use(sessionParser);
 
-    const webSocketProxy = new WebSocketProxy(authClient);
+    const webSocketProxy = new WebSocketProxy(tokenExchangeClient);
 
     config.proxyConfig.apis.forEach((api) => {
-        server.use(`/api/${api.path}*`, proxy(api.url, getProxyOptions(api, authClient)));
+        server.use(`/api/${api.path}*`, proxy(api.url, getProxyOptions(api, tokenExchangeClient)));
         const webSocket = webSocketProxy.leggTil({api});
         if (webSocket) {
             server.use(webSocket.path, webSocket.middleware);

--- a/src/server/utils/auth.js
+++ b/src/server/utils/auth.js
@@ -32,16 +32,27 @@ export const isAuthenticated = ({ request = null, tokenSets = null, id = self })
     return new TokenSet(tokenSet).expired() === false;
 };
 
-export async function getTokenOnBehalfOf({ authClient, api, request }) {
+export async function getTokenOnBehalfOf({ tokenExchangeClient, api, request }) {
     const tokenSets = getTokenSetsFromSession({ request });
     if (!isAuthenticated({ tokenSets, id: api.id })) {
-        const onBehalfTokenSet = await authClient.grant({
-            grant_type: 'urn:ietf:params:oauth:grant-type:jwt-bearer',
+        const onBehalfTokenSet = await tokenExchangeClient.grant({
+            grant_type: config.tokenExchangeGrantType,
             client_assertion_type: 'urn:ietf:params:oauth:client-assertion-type:jwt-bearer',
+            // Required for azureAd
             requested_token_use: 'on_behalf_of',
             scope: api.scopes,
             assertion: tokenSets[self].access_token,
-        }, {clientAssertionPayload: {aud: authClient.issuer.metadata['token_endpoint']}});
+            // Reuired for TokenX
+            subject_token_type: 'urn:ietf:params:oauth:token-type:jwt',
+            subject_token: tokenSets[self].access_token,
+            audience: api.scopes,
+        }, {
+            clientAssertionPayload:
+                {
+                    aud: tokenExchangeClient.issuer.metadata['token_endpoint'],
+                    nbf: Math.floor(Date.now() / 1000),
+                }
+        });
         request.session.tokenSets[api.id] = onBehalfTokenSet;
         return onBehalfTokenSet;
     } else {

--- a/src/server/utils/openidClient.js
+++ b/src/server/utils/openidClient.js
@@ -1,12 +1,13 @@
-import config from './config';
 import { httpProxy } from './httpProxy';
 import { Issuer, custom } from 'openid-client';
 import logger from './log';
 
-const metadata = {
-    client_id: config.clientId,
-    token_endpoint_auth_method: 'private_key_jwt',
-    token_endpoint_auth_signing_alg: 'RS256',
+const metadata = (clientId) => {
+    return {
+        client_id: clientId,
+        token_endpoint_auth_method: 'private_key_jwt',
+        token_endpoint_auth_signing_alg: 'RS256',
+    };
 };
 
 export function configureHttpProxy() {
@@ -20,10 +21,10 @@ export function configureHttpProxy() {
     }
 }
 
-export async function buildIssuer() {
-    return Issuer.discover(config.discoveryUrl);
+export async function buildIssuer(discoveryUrl) {
+    return Issuer.discover(discoveryUrl);
 }
 
-export function buildClient(issuer) {
-    return new issuer.Client(metadata, config.jwks);
+export function buildClient(issuer, clientId, jwks) {
+    return new issuer.Client(metadata(clientId), jwks);
 }

--- a/src/server/utils/proxy.js
+++ b/src/server/utils/proxy.js
@@ -8,7 +8,7 @@ import { ulid } from 'ulid'
 const CorrelationId = 'x-correlation-id';
 const Timestamp = 'x-timestamp';
 
-export const getProxyOptions = (api, authClient) => ({
+export const getProxyOptions = (api, tokenExchangeClient) => ({
     parseReqBody: false,
     filter: (request, response) => {
         logger.debug(`Proxy URL ${api.url}.`);
@@ -30,7 +30,7 @@ export const getProxyOptions = (api, authClient) => ({
         }
         requestOptions.headers[Timestamp] = Date.now();
         return new Promise((resolve, reject) => {
-            getTokenOnBehalfOf({ authClient, api, request }).then(
+            getTokenOnBehalfOf({ tokenExchangeClient, api, request }).then(
                 ({ token_type, access_token }) => {
                     logger.debug('Legger på Authorization header.');
                     requestOptions.headers['Authorization'] = `${token_type} ${access_token}`;

--- a/src/server/utils/wsProxy.js
+++ b/src/server/utils/wsProxy.js
@@ -27,8 +27,8 @@ const getWsProxyOptions = (api, webSocketProxyPath) => {
 };
 
 class WebSocketProxy {
-    constructor(authClient) {
-        this.authClient = authClient;
+    constructor(tokenExchangeClient) {
+        this.tokenExchangeClient = tokenExchangeClient;
         this.proxies = {};
     }
 
@@ -59,7 +59,7 @@ class WebSocketProxy {
             if (upgradeWebSocket && proxy) {
                 if (authenticated) {
                     logger.info(`Authenticated WebSocket upgrade.`);
-                    getTokenOnBehalfOf({ authClient: this.authClient, api: proxy.api, request }).then(
+                    getTokenOnBehalfOf({ tokenExchangeClient: this.tokenExchangeClient, api: proxy.api, request }).then(
                         ({ token_type, access_token }) => {
                             request.headers['Authorization'] = `${token_type} ${access_token}`;
                             proxy.upgrade(request, socket, head)

--- a/src/startup.js
+++ b/src/startup.js
@@ -1,16 +1,20 @@
 import startServer from './server';
 import { buildIssuer, buildClient, configureHttpProxy } from './server/utils/openidClient';
 import logger from './server/utils/log';
-
 import 'core-js/stable';
 import 'regenerator-runtime/runtime';
+import config from "./server/utils/config";
 
 async function startApp() {
     try {
         configureHttpProxy();
-        const issuer = await buildIssuer();
-        const client = buildClient(issuer);
-        startServer(client);
+        const issuer = await buildIssuer(config.discoveryUrl);
+        const client = buildClient(issuer, config.clientId, config.jwks);
+
+        const tokenExchangeIssuer = await buildIssuer(config.tokenExchangeDiscoveryUrl);
+        const tokenExchangeClient = buildClient(tokenExchangeIssuer, config.tokenExchangeClientId, config.tokenExchangeJwks);
+
+        startServer(client, tokenExchangeClient);
     } catch (error) {
         logger.error('Feil ved oppstart', error);
         process.exit(1);

--- a/startup-utils/create-env-file.sh
+++ b/startup-utils/create-env-file.sh
@@ -3,6 +3,7 @@
 ENV_PATH=$1
 AZURE_HOST=$2
 
+echo '' > $ENV_PATH # Lager ny fil
 echo CLIENT_ID='oidc-auth-proxy' >> $ENV_PATH
 echo JWK='{"kid": "test-cert", "kty":"RSA","n":"2g5WzL5yJESM55Sdy-r_uA5aJkwF_PPa3XSyREJMuv91BkGk1V7pdfi6sN8XFVy6rlPXuHp__XxRortqBOxBVpJfRFv9aNlQcmDZ27-39t-9FehvHfIvpwwCg-ojSxRkbPz9Dw0EnA_-WUXApG14BHMNVNEg-LRFnIO3z8CebgodM4_y9cplqhuYvrPO1wTv-6-BD_hNsMfNr99T5Seq75Meku6Qjzts8bgr5-Z_c_DOdqJ1clcA4qYjXDkdNFQcAc1MqhYt3IiKuvHscLsYTx_uOeSWGSXcPYNJygR7LGcDL-oVV71m8_O7Xd_zBY4VQNUpl1AE70rstKHP2I7CIw","e":"AQAB","d":"pBhcW9IKBZ8Mxo3Bvh6H-FPcpataakR89WEHcnTOV3886stlpyi42g2nOMl6Dpps5hm0YmDVhsYSjTsqiq_cb7DRPplXd5rqfljCOivp3j_7hMwZKtkB4V0ZW3pMuwiKlrZAHh521Jb4mufyFAtJYVfPtX93p5HKPQGmxxI2Z6mTI4Te4nUY7lGNUovVHb3TDgTlLhg2jn1IsN8-GFpuGqJVpKS5lR6aKNZ8V0O0VIOBVmkjS9650MxanFXTH1MmeiWmmIQjailxmBbdY3EC44puxxuixbFrslShDDWz4FzPc52bUxR7n05PssPwmKwdY9k6CDKe-guOJc_r_wf3YQ","p":"8bbeDEAGYEW2sle0H_iDD7pBexDuGMRnqAeAjAh-dbUViaqJfgeh3xVRYs8r-Sv5HCUCkb0DAKDtZnEFi6kUOG32UaNA9Yo0UpZncBWJqdu3TT-wJwZW60UfhCS7cWaYCmrb9KiVQEarp_OCuY6b9Go2NPJIsK84cSunC2naczM","q":"5vGFm12HdYzzpWNql6ntBf96HzUf-R9z7t_P-seULZO6C_I4CWZqLAjnN9DCZU8Fx5nkZdggXuqwNnSSK_tjUlsW1n5i69R14y8PZB6IU8M4HWqUzhO8ix6ku05-MhanvHpDGq91entWRbqAAWWQTINZOsjKBVfRHsvR3u0OdVE","dp":"zmN9j-ovR47fI8K9W7sfdZNtC_71vpIdjBzzxx4NlMYNYOILymAL-GbEemE5Q-YnK7_yRKymXqgKbTk-KfUx_cju1OBXvBDJAmfIZK0PQckI593ktD22g-cetP-ESZz3X5XEwFAeOKbfNWY4jeZWBcmXBXiHVs4WnJNQa-9zhn8","dq":"2OeE9hxNKrHc8LxEE_gsPxLpL0BlLEVHTNb27vHeEUSLW8b-rI19MKiYCctPmXkz03mNk73_AUbpg-vOkfKFIYeeFo0T-a1Nn7fGe-FVZ16WaMJ-ymKtFfkM_UNGsWKn3hTyy7B55TTMHaeBrE4ozkQbXWPSolwNdCA4mGkLyFE","qi":"4lv0L8PPyRRhLNDK5t2nnqAwVMltYQ8YuFEjMckYCjN71p5D9M7TB2ZVQyhoOaLsBinBFDWOW_wFSMQH_7Qjfskg57g8rweKZDfnWhIkc_0P3-I5tr45SOxP-fW7rsRf_qk319tc8xpROdlyoSYQQvCB50DRBRSDYVbUwhZ61BM"}' >> $ENV_PATH
 echo DISCOVERY_URL="'http://$AZURE_HOST:8100/v2.0/.well-known/openid-configuration?name=Gizmo%20The%20Cat&user_id=1337'" >> $ENV_PATH
@@ -11,7 +12,7 @@ echo PROXY_CONFIG="'{\"apis\":[{\"path\":\"azure-mock\",\"url\":\"http://$AZURE_
 echo OIDC_AUTH_PROXY_BASE_URL="'http://localhost:8101'" >> $ENV_PATH
 echo APPLICATION_BASE_URL="'http://localhost:8101/api/azure-mock/audience-check'" >> $ENV_PATH
 
-echo PORT='8101' > $ENV_PATH
+echo PORT='8101' >> $ENV_PATH
 echo SESSION_ID_COOKIE_NAME='oidc-auth-proxy' >> $ENV_PATH
 echo SESSION_ID_COOKIE_SIGN_SECRET='foo' >> $ENV_PATH
 echo SESSION_ID_COOKIE_VERIFY_SECRET='bar' >> $ENV_PATH

--- a/startup-utils/create-env-file.sh
+++ b/startup-utils/create-env-file.sh
@@ -3,14 +3,15 @@
 ENV_PATH=$1
 AZURE_HOST=$2
 
-echo PORT='8101' > $ENV_PATH
 echo CLIENT_ID='oidc-auth-proxy' >> $ENV_PATH
 echo JWK='{"kid": "test-cert", "kty":"RSA","n":"2g5WzL5yJESM55Sdy-r_uA5aJkwF_PPa3XSyREJMuv91BkGk1V7pdfi6sN8XFVy6rlPXuHp__XxRortqBOxBVpJfRFv9aNlQcmDZ27-39t-9FehvHfIvpwwCg-ojSxRkbPz9Dw0EnA_-WUXApG14BHMNVNEg-LRFnIO3z8CebgodM4_y9cplqhuYvrPO1wTv-6-BD_hNsMfNr99T5Seq75Meku6Qjzts8bgr5-Z_c_DOdqJ1clcA4qYjXDkdNFQcAc1MqhYt3IiKuvHscLsYTx_uOeSWGSXcPYNJygR7LGcDL-oVV71m8_O7Xd_zBY4VQNUpl1AE70rstKHP2I7CIw","e":"AQAB","d":"pBhcW9IKBZ8Mxo3Bvh6H-FPcpataakR89WEHcnTOV3886stlpyi42g2nOMl6Dpps5hm0YmDVhsYSjTsqiq_cb7DRPplXd5rqfljCOivp3j_7hMwZKtkB4V0ZW3pMuwiKlrZAHh521Jb4mufyFAtJYVfPtX93p5HKPQGmxxI2Z6mTI4Te4nUY7lGNUovVHb3TDgTlLhg2jn1IsN8-GFpuGqJVpKS5lR6aKNZ8V0O0VIOBVmkjS9650MxanFXTH1MmeiWmmIQjailxmBbdY3EC44puxxuixbFrslShDDWz4FzPc52bUxR7n05PssPwmKwdY9k6CDKe-guOJc_r_wf3YQ","p":"8bbeDEAGYEW2sle0H_iDD7pBexDuGMRnqAeAjAh-dbUViaqJfgeh3xVRYs8r-Sv5HCUCkb0DAKDtZnEFi6kUOG32UaNA9Yo0UpZncBWJqdu3TT-wJwZW60UfhCS7cWaYCmrb9KiVQEarp_OCuY6b9Go2NPJIsK84cSunC2naczM","q":"5vGFm12HdYzzpWNql6ntBf96HzUf-R9z7t_P-seULZO6C_I4CWZqLAjnN9DCZU8Fx5nkZdggXuqwNnSSK_tjUlsW1n5i69R14y8PZB6IU8M4HWqUzhO8ix6ku05-MhanvHpDGq91entWRbqAAWWQTINZOsjKBVfRHsvR3u0OdVE","dp":"zmN9j-ovR47fI8K9W7sfdZNtC_71vpIdjBzzxx4NlMYNYOILymAL-GbEemE5Q-YnK7_yRKymXqgKbTk-KfUx_cju1OBXvBDJAmfIZK0PQckI593ktD22g-cetP-ESZz3X5XEwFAeOKbfNWY4jeZWBcmXBXiHVs4WnJNQa-9zhn8","dq":"2OeE9hxNKrHc8LxEE_gsPxLpL0BlLEVHTNb27vHeEUSLW8b-rI19MKiYCctPmXkz03mNk73_AUbpg-vOkfKFIYeeFo0T-a1Nn7fGe-FVZ16WaMJ-ymKtFfkM_UNGsWKn3hTyy7B55TTMHaeBrE4ozkQbXWPSolwNdCA4mGkLyFE","qi":"4lv0L8PPyRRhLNDK5t2nnqAwVMltYQ8YuFEjMckYCjN71p5D9M7TB2ZVQyhoOaLsBinBFDWOW_wFSMQH_7Qjfskg57g8rweKZDfnWhIkc_0P3-I5tr45SOxP-fW7rsRf_qk319tc8xpROdlyoSYQQvCB50DRBRSDYVbUwhZ61BM"}' >> $ENV_PATH
 echo DISCOVERY_URL="'http://$AZURE_HOST:8100/v2.0/.well-known/openid-configuration?name=Gizmo%20The%20Cat&user_id=1337'" >> $ENV_PATH
 echo LOGIN_SCOPES="'openid profile oidc-auth-proxy/.default'" >> $ENV_PATH
+echo PROXY_CONFIG="'{\"apis\":[{\"path\":\"azure-mock\",\"url\":\"http://$AZURE_HOST:8100\",\"scopes\":\"azure-mock/.default\"},{\"path\":\"websocket-server\",\"url\":\"http://host.docker.internal:1338\",\"scopes\":\"websocket-server/.default\",\"webSocketUrl\": \"ws://host.docker.internal:1338/ws\"}]}'" >> $ENV_PATH
 echo OIDC_AUTH_PROXY_BASE_URL="'http://localhost:8101'" >> $ENV_PATH
 echo APPLICATION_BASE_URL="'http://localhost:8101/api/azure-mock/audience-check'" >> $ENV_PATH
-echo PROXY_CONFIG="'{\"apis\":[{\"path\":\"azure-mock\",\"url\":\"http://$AZURE_HOST:8100\",\"scopes\":\"azure-mock/.default\"},{\"path\":\"websocket-server\",\"url\":\"http://host.docker.internal:1338\",\"scopes\":\"websocket-server/.default\",\"webSocketUrl\": \"ws://host.docker.internal:1338/ws\"}]}'" >> $ENV_PATH
+
+echo PORT='8101' > $ENV_PATH
 echo SESSION_ID_COOKIE_NAME='oidc-auth-proxy' >> $ENV_PATH
 echo SESSION_ID_COOKIE_SIGN_SECRET='foo' >> $ENV_PATH
 echo SESSION_ID_COOKIE_VERIFY_SECRET='bar' >> $ENV_PATH


### PR DESCRIPTION
Muliggjør at token-exchange kan gjøres med en annen flyt enn authentication_code_flow

Dette er nødvendig ved brukerautentisering mot idporten, fordi idporten ikke har noen god løsning for token-exchange.
Derfor har NAIS laget en egen løsning for dette kalt TokenX.
For brukerautentisering vil derfor authorization_code_flow gjøre direkte mot idporten, mens token-exchange gjøres via TokenX.

La til mer dokumentasjon på hvordan appen kan kjøres opp lokalt mot AzureAd og Idporten/TokenX direkte.